### PR TITLE
get-client + create-client support autoapprove [fixes #8]

### DIFF
--- a/cmd/create_client.go
+++ b/cmd/create_client.go
@@ -30,7 +30,7 @@ func CreateClientPreRunValidations(cfg uaa.Config, args []string) error {
 	return nil
 }
 
-func CreateClientCmd(cm *uaa.ClientManager, clone, clientId, clientSecret, displayName, authorizedGrantTypes, authorities, redirectUri, scope string, accessTokenValidity int64, refreshTokenValidity int64) error {
+func CreateClientCmd(cm *uaa.ClientManager, clone, clientId, clientSecret, displayName, authorizedGrantTypes, authorities, autoapprove, redirectUri, scope string, accessTokenValidity int64, refreshTokenValidity int64) error {
 	var toCreate uaa.Client
 	var err error
 	if clone != "" {
@@ -49,6 +49,9 @@ func CreateClientCmd(cm *uaa.ClientManager, clone, clientId, clientSecret, displ
 		}
 		if authorities != "" {
 			toCreate.Authorities = arrayify(authorities)
+		}
+		if autoapprove != "" {
+			toCreate.AutoApprove = arrayify(autoapprove)
 		}
 		if redirectUri != "" {
 			toCreate.RedirectURI = arrayify(redirectUri)
@@ -69,6 +72,7 @@ func CreateClientCmd(cm *uaa.ClientManager, clone, clientId, clientSecret, displ
 		toCreate.DisplayName = displayName
 		toCreate.AuthorizedGrantTypes = arrayify(authorizedGrantTypes)
 		toCreate.Authorities = arrayify(authorities)
+		toCreate.AutoApprove = arrayify(autoapprove)
 		toCreate.RedirectURI = arrayify(redirectUri)
 		toCreate.Scope = arrayify(scope)
 		toCreate.AccessTokenValidity = accessTokenValidity
@@ -108,6 +112,7 @@ var createClientCmd = &cobra.Command{
 			displayName,
 			authorizedGrantTypes,
 			authorities,
+			autoapprove,
 			redirectUri,
 			scope,
 			accessTokenValidity,
@@ -121,8 +126,9 @@ func init() {
 	createClientCmd.Annotations = make(map[string]string)
 	createClientCmd.Annotations[CLIENT_CRUD_CATEGORY] = "true"
 	createClientCmd.Flags().StringVarP(&clientSecret, "client_secret", "s", "", "client secret")
-	createClientCmd.Flags().StringVarP(&authorizedGrantTypes, "authorized_grant_types", "", "", "list of grant types allowed with this client.")
+	createClientCmd.Flags().StringVarP(&authorizedGrantTypes, "authorized_grant_types", "", "", "list of grant types allowed with this client")
 	createClientCmd.Flags().StringVarP(&authorities, "authorities", "", "", "scopes requested by client during client_credentials grant")
+	createClientCmd.Flags().StringVarP(&autoapprove, "autoapprove", "", "", "Scopes that do not require user approval")
 	createClientCmd.Flags().StringVarP(&scope, "scope", "", "", "scopes requested by client during authorization_code, implicit, or password grants")
 	createClientCmd.Flags().Int64VarP(&accessTokenValidity, "access_token_validity", "", 0, "the time in seconds before issued access tokens expire")
 	createClientCmd.Flags().Int64VarP(&refreshTokenValidity, "refresh_token_validity", "", 0, "the time in seconds before issued refrsh tokens expire")

--- a/cmd/create_client_test.go
+++ b/cmd/create_client_test.go
@@ -1,6 +1,8 @@
 package cmd_test
 
 import (
+	"net/http"
+
 	"code.cloudfoundry.org/uaa-cli/config"
 	"github.com/cloudfoundry-community/go-uaa"
 	. "github.com/onsi/ginkgo"
@@ -8,7 +10,6 @@ import (
 	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
 	. "github.com/onsi/gomega/ghttp"
-	"net/http"
 )
 
 var _ = Describe("CreateClient", func() {
@@ -18,10 +19,10 @@ var _ = Describe("CreateClient", func() {
 	  "client_secret" : "secret",
 	  "resource_ids" : [ ],
 	  "authorized_grant_types" : [ "client_credentials", "authorization_code" ],
+	  "autoapprove" : ["true"],
 	  "redirect_uri" : [ "http://localhost:8080/*" ],
 	  "authorities" : [ "notifications.write", "notifications.read" ],
 	  "token_salt" : "",
-	  "autoapprove" : ["true"],
 	  "allowedproviders" : [ "uaa", "ldap", "my-saml-provider" ],
 	  "name" : "Notifier Client"
 	}`
@@ -169,7 +170,7 @@ var _ = Describe("CreateClient", func() {
 					VerifyHeaderKV("Authorization", "bearer access_token"),
 				))
 
-				shinyCopy := `{"client_id":"shinycopy","client_secret":"secretsecret", "scope":["shiny.write"],"authorized_grant_types":["client_credentials","authorization_code"],"redirect_uri":["http://localhost:8080/*"],"authorities":["shiny.write","shiny.read"],"allowedproviders":["uaa","ldap","my-saml-provider"],"name":"The Shiniest Client"}`
+				shinyCopy := `{"client_id":"shinycopy","client_secret":"secretsecret", "scope":["shiny.write"],"authorized_grant_types":["client_credentials","authorization_code"],"autoapprove":["true"],"redirect_uri":["http://localhost:8080/*"],"authorities":["shiny.write","shiny.read"],"allowedproviders":["uaa","ldap","my-saml-provider"],"name":"The Shiniest Client"}`
 				server.RouteToHandler("POST", "/oauth/clients", CombineHandlers(
 					VerifyRequest("POST", "/oauth/clients"),
 					RespondWith(http.StatusOK, shinyCopy),
@@ -193,7 +194,7 @@ var _ = Describe("CreateClient", func() {
 					VerifyHeaderKV("Authorization", "bearer access_token"),
 				))
 
-				shinyCopy := `{"client_id":"shinycopy","client_secret":"secretsecret", "scope":["foo.read"],"authorized_grant_types":["implicit"],"redirect_uri":["http://localhost:8001/*"],"authorities":["shiny.read"],"allowedproviders":["uaa","ldap","my-saml-provider"],"name":"foo client", "access_token_validity": 3600, "refresh_token_validity": 4500}`
+				shinyCopy := `{"client_id":"shinycopy","client_secret":"secretsecret", "scope":["foo.read"],"authorized_grant_types":["implicit"],"autoapprove":["true"],"redirect_uri":["http://localhost:8001/*"],"authorities":["shiny.read"],"allowedproviders":["uaa","ldap","my-saml-provider"],"name":"foo client", "access_token_validity": 3600, "refresh_token_validity": 4500}`
 				server.RouteToHandler("POST", "/oauth/clients", CombineHandlers(
 					VerifyRequest("POST", "/oauth/clients"),
 					RespondWith(http.StatusOK, shinyCopy),
@@ -241,7 +242,7 @@ var _ = Describe("CreateClient", func() {
 					VerifyHeaderKV("Authorization", "bearer access_token"),
 				))
 
-				shinyCopy := `{"client_id":"shinycopy","client_secret":"secretsecret", "authorities":["shiny.write","shiny.read"], "scope":["shiny.write"],"authorized_grant_types":["client_credentials","authorization_code"],"redirect_uri":["http://localhost:8080/*"],"allowedproviders":["uaa","ldap","my-saml-provider"],"name":"The Shiniest Client"}`
+				shinyCopy := `{"client_id":"shinycopy","client_secret":"secretsecret", "authorities":["shiny.write","shiny.read"], "scope":["shiny.write"],"authorized_grant_types":["client_credentials","authorization_code"],"autoapprove":["true"],"redirect_uri":["http://localhost:8080/*"],"allowedproviders":["uaa","ldap","my-saml-provider"],"name":"The Shiniest Client"}`
 				server.RouteToHandler("POST", "/oauth/clients", CombineHandlers(
 					VerifyRequest("POST", "/oauth/clients"),
 					RespondWith(http.StatusBadRequest, shinyCopy),
@@ -299,7 +300,7 @@ var _ = Describe("CreateClient", func() {
 					VerifyHeaderKV("Authorization", "bearer access_token"),
 				))
 
-				implicitCopy := `{ "scope" : [ "implicit.write" ], "client_id" : "implicitcopy", "authorized_grant_types" : [ "implicit" ], "redirect_uri" : [ "http://localhost:8080/*" ], "authorities" : [ "implicit.write", "implicit.read" ], "allowedproviders" : [ "uaa", "ldap", "my-saml-provider" ], "name" : "Implicit Client" }`
+				implicitCopy := `{ "scope" : [ "implicit.write" ], "client_id" : "implicitcopy", "authorized_grant_types" : [ "implicit" ], "autoapprove" : [ "true" ], "redirect_uri" : [ "http://localhost:8080/*" ], "authorities" : [ "implicit.write", "implicit.read" ], "allowedproviders" : [ "uaa", "ldap", "my-saml-provider" ], "name" : "Implicit Client" }`
 
 				server.RouteToHandler("POST", "/oauth/clients", CombineHandlers(
 					VerifyRequest("POST", "/oauth/clients"),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,8 +7,8 @@ import (
 	"code.cloudfoundry.org/uaa-cli/cli"
 	"code.cloudfoundry.org/uaa-cli/config"
 	"code.cloudfoundry.org/uaa-cli/help"
-	"github.com/cloudfoundry-community/go-uaa"
 	"code.cloudfoundry.org/uaa-cli/version"
+	"github.com/cloudfoundry-community/go-uaa"
 	"github.com/spf13/cobra"
 )
 
@@ -33,6 +33,7 @@ var (
 	clientSecret         string
 	authorizedGrantTypes string
 	authorities          string
+	autoapprove          string
 	accessTokenValidity  int64
 	refreshTokenValidity int64
 	displayName          string


### PR DESCRIPTION
Demo

```
$ make build
$ build/uaa create-client padmin -s padmin --authorized_grant_types password --clone admin --autoapprove true
The client padmin has been successfully created.
{
  "client_id": "padmin",
  "scope": [
    "openid"
  ],
  "resource_ids": [
    "none"
  ],
  "authorized_grant_types": [
    "password",
    "refresh_token"
  ],
  "autoapprove": [
    "true"
  ],
  "authorities": [
    "bosh.admin"
  ],
  "lastModified": 1531205904779
}
```