### PR TITLE
Add delete user command

### DIFF
--- a/cmd/delete_user.go
+++ b/cmd/delete_user.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"code.cloudfoundry.org/uaa-cli/config"
+	"code.cloudfoundry.org/uaa-cli/utils"
+	"errors"
+	"github.com/cloudfoundry-community/go-uaa"
+	"github.com/spf13/cobra"
+)
+
+func DeleteUserCmd(api *uaa.API, username, origin, attributes string) error {
+	user, err := api.GetUserByUsername(username, origin, attributes)
+	if err != nil {
+		return err
+	}
+
+	_, err = api.DeleteUser(user.ID)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Account for user %v successfully deleted.", utils.Emphasize(user.Username))
+	return nil
+}
+
+func DeleteUserValidations(cfg config.Config, args []string) error {
+	if err := EnsureContextInConfig(cfg); err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		return errors.New("The positional argument USERNAME must be specified.")
+	}
+	return nil
+}
+
+var deleteUserCmd = &cobra.Command{
+	Use:   "delete-user USERNAME",
+	Short: "Delete a user by username",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		err := DeleteUserValidations(GetSavedConfig(), args)
+		NotifyValidationErrors(err, cmd, log)
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		err := DeleteUserCmd(GetAPIFromSavedTokenInContext(), args[0], origin, attributes)
+		NotifyErrorsWithRetry(err, log)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(deleteUserCmd)
+	deleteUserCmd.Annotations = make(map[string]string)
+	deleteUserCmd.Annotations[USER_CRUD_CATEGORY] = "true"
+
+	deleteUserCmd.Flags().StringVarP(&origin, "origin", "o", "uaa", "user origin")
+}

--- a/cmd/delete_user_test.go
+++ b/cmd/delete_user_test.go
@@ -1,0 +1,73 @@
+package cmd_test
+
+import (
+	"net/http"
+
+	"code.cloudfoundry.org/uaa-cli/config"
+	"code.cloudfoundry.org/uaa-cli/fixtures"
+	"github.com/cloudfoundry-community/go-uaa"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+	. "github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("DeleteUser", func() {
+	BeforeEach(func() {
+		c := config.NewConfigWithServerURL(server.URL())
+		ctx := config.NewContextWithToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ")
+		c.AddContext(ctx)
+		Expect(config.WriteConfig(c)).Should(Succeed())
+	})
+
+	It("delete a user", func() {
+		server.RouteToHandler("GET", "/Users", CombineHandlers(
+			VerifyRequest("GET", "/Users", "count=100&filter=userName+eq+%22woodstock%40peanuts.com%22&startIndex=1"),
+			RespondWith(http.StatusOK, fixtures.PaginatedResponse(uaa.User{Username: "woodstock@peanuts.com", ID: "abcdef", Meta: &uaa.Meta{Version: 10}})),
+		))
+		server.RouteToHandler("DELETE", "/Users/abcdef", CombineHandlers(
+			VerifyRequest("DELETE", "/Users/abcdef"),
+			RespondWith(http.StatusOK, fixtures.PaginatedResponse(uaa.User{Username: "woodstock@peanuts.com"})),
+		))
+
+		session := runCommand("delete-user", "woodstock@peanuts.com")
+
+		Expect(server.ReceivedRequests()).To(HaveLen(2))
+		Eventually(session).Should(Exit(0))
+		Expect(session.Out).To(Say("Account for user woodstock@peanuts.com successfully deleted."))
+	})
+
+	Describe("validations", func() {
+		It("requires a target", func() {
+			config.WriteConfig(config.NewConfig())
+
+			session := runCommand("delete-user", "woodstock@peanuts.com")
+
+			Expect(session.Err).To(Say("You must set a target in order to use this command."))
+			Expect(session).Should(Exit(1))
+		})
+
+		It("requires a context", func() {
+			cfg := config.NewConfigWithServerURL(server.URL())
+			config.WriteConfig(cfg)
+
+			session := runCommand("delete-user", "woodstock@peanuts.com")
+
+			Expect(session.Err).To(Say("You must have a token in your context to perform this command."))
+			Expect(session).Should(Exit(1))
+		})
+
+		It("requires a username", func() {
+			c := config.NewConfigWithServerURL(server.URL())
+			ctx := config.NewContextWithToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ")
+			c.AddContext(ctx)
+			config.WriteConfig(c)
+
+			session := runCommand("delete-user")
+
+			Expect(session.Err).To(Say("The positional argument USERNAME must be specified."))
+			Expect(session).Should(Exit(1))
+		})
+	})
+})


### PR DESCRIPTION
### Why?
- As of now there is no user deletion command, which was supported by `uaac` cli 

### Changes?
- Added `delete-user` command
- Added test suite for delete user command

#### Cli experience

```
uaa cli help view

Managing Users:
  activate-user                 Activate a user by username
  create-user                   Create a user
  deactivate-user               Deactivate a user by username
  delete-user                   Delete a user by username
  get-user                      Look up a user by username
  list-users                    Search and list users with SCIM filters
```
```
$ uaa delete-user
The positional argument USERNAME must be specified.
Usage:
  uaa delete-user USERNAME [flags]

Flags:
  -h, --help            help for delete-user
  -o, --origin string   user origin (default "uaa")

Global Flags:
  -v, --verbose   See additional info on HTTP requests
```
```
$ uaa delete-user ronakbanka
Account for user ronakbanka successfully deleted.
```